### PR TITLE
Remove Dave's Free Press until we can fix the problems.

### DIFF
--- a/perlsphere.yaml
+++ b/perlsphere.yaml
@@ -23,7 +23,6 @@ plugins:
         - url:   http://szabgab.com/blog/Perl.rss
           title: Gabor Szabo
         - url:   http://feeds2.feedburner.com/DamienLearnsPerl
-        - url:   http://www.cantrell.org.uk/david/journal/index.pl/keyword_perl?format=rss
         - url:   http://leto.net/dukeleto.pl/atom.xml
         - url:   http://jquelin.blogspot.com/feeds/posts/default?alt=rss
           title: Jérôme Quelin


### PR DESCRIPTION
Old posts seem to be reposted annoyingly frequently.