### PR TITLE
Add the atom link for ology.github.io

### DIFF
--- a/perlsphere.yaml
+++ b/perlsphere.yaml
@@ -133,6 +133,8 @@ plugins:
         - url:   http://news.perlfoundation.org/atom.xml
           title: Perl Foundation News
         - url:   https://dilfridge.blogspot.com/feeds/posts/default/-/perl/
+        - url:   https://ology.github.io/index.atom
+          title: Gene Boggs
 
   # Load 'Bundle' planet plugins
   - module: Bundle::Planet


### PR DESCRIPTION
This commit adds the atom link for Gene Boggs' (mostly perl) blog.